### PR TITLE
feat(sitemap): adds map and filter buttons to sitemap page

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
-  "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "editor.codeActionsOnSave": {
+      "source.fixAll.eslint": true
+    },
+    "typescript.tsdk": "node_modules/typescript/lib"
   }
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,13 +11,16 @@
         "@headlessui/react": "^1.7.17",
         "@supabase/supabase-js": "^2.36.0",
         "axios": "^1.5.1",
+        "leaflet": "^1.9.4",
         "next": "latest",
         "react": "latest",
-        "react-dom": "latest"
+        "react-dom": "latest",
+        "react-leaflet": "^4.2.1"
       },
       "devDependencies": {
         "@calblueprint/eslint-config-react": "^0.0.3",
         "@calblueprint/prettier-config": "^0.0.1",
+        "@types/leaflet": "^1.9.6",
         "@types/node": "latest",
         "@types/react": "latest",
         "@types/react-dom": "latest",
@@ -437,6 +440,16 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@react-leaflet/core": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-2.1.0.tgz",
+      "integrity": "sha512-Qk7Pfu8BSarKGqILj4x7bCSZ1pjuAPZ+qmRwH5S7mDS91VSbVVsJSrW4qA+GPrro8t69gFYVMWb1Zc4yFmPiVg==",
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
     "node_modules/@rushstack/eslint-patch": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.5.0.tgz",
@@ -517,6 +530,12 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.11",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.11.tgz",
+      "integrity": "sha512-L7A0AINMXQpVwxHJ4jxD6/XjZ4NDufaRlUJHjNIFKYUFBH1SvOW+neaqb0VTRSLW5suSrSu19ObFEFnfNcr+qg==",
+      "dev": true
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.13",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.13.tgz",
@@ -528,6 +547,15 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
+    },
+    "node_modules/@types/leaflet": {
+      "version": "1.9.6",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.6.tgz",
+      "integrity": "sha512-HakGTK5LBBWegNWsAmTlG55zN1zszYec7aG47/z6SzT90bW2vqjmbqk3YKAbrtveO+G7fSTKTYqVbIwAFnTrbg==",
+      "dev": true,
+      "dependencies": {
+        "@types/geojson": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "20.7.0",
@@ -3345,6 +3373,11 @@
         "language-subtag-registry": "~0.3.2"
       }
     },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA=="
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -4333,6 +4366,19 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
+    },
+    "node_modules/react-leaflet": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-4.2.1.tgz",
+      "integrity": "sha512-p9chkvhcKrWn/H/1FFeVSqLdReGwn2qmiobOQGO3BifX+/vV/39qhY8dGqbdcPh1e6jxh/QHriLXr7a4eLFK4Q==",
+      "dependencies": {
+        "@react-leaflet/core": "^2.1.0"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
     },
     "node_modules/read-cache": {
       "version": "1.0.0",
@@ -5752,6 +5798,12 @@
         "fastq": "^1.6.0"
       }
     },
+    "@react-leaflet/core": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-2.1.0.tgz",
+      "integrity": "sha512-Qk7Pfu8BSarKGqILj4x7bCSZ1pjuAPZ+qmRwH5S7mDS91VSbVVsJSrW4qA+GPrro8t69gFYVMWb1Zc4yFmPiVg==",
+      "requires": {}
+    },
     "@rushstack/eslint-patch": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.5.0.tgz",
@@ -5829,6 +5881,12 @@
         "tslib": "^2.4.0"
       }
     },
+    "@types/geojson": {
+      "version": "7946.0.11",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.11.tgz",
+      "integrity": "sha512-L7A0AINMXQpVwxHJ4jxD6/XjZ4NDufaRlUJHjNIFKYUFBH1SvOW+neaqb0VTRSLW5suSrSu19ObFEFnfNcr+qg==",
+      "dev": true
+    },
     "@types/json-schema": {
       "version": "7.0.13",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.13.tgz",
@@ -5840,6 +5898,15 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
+    },
+    "@types/leaflet": {
+      "version": "1.9.6",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.6.tgz",
+      "integrity": "sha512-HakGTK5LBBWegNWsAmTlG55zN1zszYec7aG47/z6SzT90bW2vqjmbqk3YKAbrtveO+G7fSTKTYqVbIwAFnTrbg==",
+      "dev": true,
+      "requires": {
+        "@types/geojson": "*"
+      }
     },
     "@types/node": {
       "version": "20.7.0",
@@ -7872,6 +7939,11 @@
         "language-subtag-registry": "~0.3.2"
       }
     },
+    "leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA=="
+    },
     "levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -8516,6 +8588,14 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
+    },
+    "react-leaflet": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-4.2.1.tgz",
+      "integrity": "sha512-p9chkvhcKrWn/H/1FFeVSqLdReGwn2qmiobOQGO3BifX+/vV/39qhY8dGqbdcPh1e6jxh/QHriLXr7a4eLFK4Q==",
+      "requires": {
+        "@react-leaflet/core": "^2.1.0"
+      }
     },
     "read-cache": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -13,13 +13,16 @@
     "@headlessui/react": "^1.7.17",
     "@supabase/supabase-js": "^2.36.0",
     "axios": "^1.5.1",
+    "leaflet": "^1.9.4",
     "next": "latest",
     "react": "latest",
-    "react-dom": "latest"
+    "react-dom": "latest",
+    "react-leaflet": "^4.2.1"
   },
   "devDependencies": {
     "@calblueprint/eslint-config-react": "^0.0.3",
     "@calblueprint/prettier-config": "^0.0.1",
+    "@types/leaflet": "^1.9.6",
     "@types/node": "latest",
     "@types/react": "latest",
     "@types/react-dom": "latest",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,6 +2,21 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer utilities {
+  @variants responsive {
+    /* Hide scrollbar for Chrome, Safari and Opera */
+    .no-scrollbar::-webkit-scrollbar {
+      display: none;
+    }
+
+    /* Hide scrollbar for IE, Edge and Firefox */
+    .no-scrollbar {
+      -ms-overflow-style: none; /* IE and Edge */
+      scrollbar-width: none; /* Firefox */
+    }
+  }
+}
+
 :root {
   --foreground-rgb: 0, 0, 0;
   --background-start-rgb: 214, 219, 220;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import './globals.css';
 import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
@@ -16,6 +17,19 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
+      <head>
+        <link
+          rel="stylesheet"
+          href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+          integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+          crossOrigin=""
+        />
+        <script
+          src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+          integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
+          crossOrigin=""
+         />
+      </head>
       <body className={inter.className}>{children}</body>
     </html>
   );

--- a/src/app/siteMapPage/page.tsx
+++ b/src/app/siteMapPage/page.tsx
@@ -1,17 +1,55 @@
 'use client';
 
 import React from 'react';
+import dynamic from 'next/dynamic';
 import NavBar from '../../components/userComponents/navBar/navBar';
 
-function App() {
+const filterButtonContent: string[] = [
+  'Buildings & Services',
+  'Pools, Aviaries, Enclosures',
+  'Site Features',
+];
+
+const SiteMap = dynamic(
+  () => import('../../components/userComponents/SiteMap/SiteMap'),
+  {
+    ssr: false,
+    loading: () => <p>Loading...</p>,
+  },
+);
+
+function MapPage() {
+  // TODO: ask about expected styling when button selected – able to filter on multiple conds?
   return (
-    <div style={{ backgroundColor: '#ebf0e4', height: '100vh' }}>
+    <>
       <NavBar />
-      <div style={{ padding: '16px' }}>
-        <h1 style={{ color: '#333333', fontSize: '2rem', fontWeight: 700 }}>Site Map</h1>
+      <div className="flex flex-col items-start pl-6">
+        <div className="container mb-6 mt-9">
+          <h1 style={{ fontSize: '2rem', fontWeight: 700 }}>Site Map</h1>
+          <div className="inline-flex flex-row items-center gap-x-2.5 w-full overflow-x-scroll no-scrollbar">
+            {filterButtonContent &&
+              filterButtonContent.map(text => (
+                <button
+                  key={text}
+                  type="button"
+                  className="bg-[#4b711d]/[0.13] text-white py-2 px-4 rounded-full whitespace-nowrap"
+                  style={{
+                    border: '1px solid #4B711D',
+                    flexWrap: 'nowrap',
+                    color: '#4B711D',
+                  }}
+                >
+                  {text}
+                </button>
+              ))}
+          </div>
+        </div>
+        <div className=" w-full pr-6 flex h-2/3 mb-6">
+          <SiteMap />
+        </div>
       </div>
-    </div>
+    </>
   );
 }
 
-export default App;
+export default MapPage;

--- a/src/app/siteMapPage/page.tsx
+++ b/src/app/siteMapPage/page.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import dynamic from 'next/dynamic';
 import NavBar from '../../components/userComponents/navBar/navBar';
+import FilterButton from '../../components/userComponents/FilterButton/FilterButton';
 
 const filterButtonContent: string[] = [
   'Buildings & Services',
@@ -19,7 +20,6 @@ const SiteMap = dynamic(
 );
 
 function MapPage() {
-  // TODO: ask about expected styling when button selected – able to filter on multiple conds?
   return (
     <>
       <NavBar />
@@ -29,18 +29,7 @@ function MapPage() {
           <div className="inline-flex flex-row items-center gap-x-2.5 w-full overflow-x-scroll no-scrollbar">
             {filterButtonContent &&
               filterButtonContent.map(text => (
-                <button
-                  key={text}
-                  type="button"
-                  className="bg-[#4b711d]/[0.13] text-white py-2 px-4 rounded-full whitespace-nowrap"
-                  style={{
-                    border: '1px solid #4B711D',
-                    flexWrap: 'nowrap',
-                    color: '#4B711D',
-                  }}
-                >
-                  {text}
-                </button>
+                <FilterButton key={text} content={text} />
               ))}
           </div>
         </div>

--- a/src/app/siteMapPage/page.tsx
+++ b/src/app/siteMapPage/page.tsx
@@ -44,7 +44,7 @@ function MapPage() {
               ))}
           </div>
         </div>
-        <div className=" w-full pr-6 flex h-2/3 mb-6">
+        <div className=" w-full pr-6 flex h-2/3 mb-8">
           <SiteMap />
         </div>
       </div>

--- a/src/components/userComponents/FilterButton/FilterButton.tsx
+++ b/src/components/userComponents/FilterButton/FilterButton.tsx
@@ -1,0 +1,32 @@
+import React, { useState } from 'react';
+
+interface FilterButtonProps {
+  content: string;
+  onClick?: () => void;
+}
+
+function FilterButton({ content, ...children }: FilterButtonProps) {
+  const [isSelected, setIsSelected] = useState<boolean>(false);
+  
+  const defaultStyle = 'bg-[#4b711d]/[0.13] text-[#4B711D] border-[#547829]';
+  const selectedStyle = 'bg-[#547829] text-white border-[#547829]';
+
+  const handleClick = () => {
+    setIsSelected(!isSelected);
+  };
+
+  return (
+    <button
+      type="button"
+      className={`${
+        isSelected ? selectedStyle : defaultStyle
+      } py-2 px-4 rounded-full whitespace-nowrap border border-solid flex-nowrap`}
+      onClick={handleClick}
+      {...children}
+    >
+      {content}
+    </button>
+  );
+}
+
+export default FilterButton;

--- a/src/components/userComponents/SiteMap/SiteMap.tsx
+++ b/src/components/userComponents/SiteMap/SiteMap.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { LatLngExpression } from 'leaflet';
+import React from 'react';
+import {
+  LayersControl,
+  MapContainer,
+  TileLayer,
+  Marker,
+  Popup,
+  ZoomControl,
+} from 'react-leaflet';
+
+const center: LatLngExpression = {
+  lat: 37.25323057233323,
+  lng: -122.08556629289924,
+};
+
+const tileLayer: { attribution: string; url: string } = {
+  attribution:
+    '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors',
+  url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+};
+
+function SiteMap() {
+  return (
+    <MapContainer
+      center={center}
+      zoom={18}
+      zoomControl={false}
+      scrollWheelZoom
+      style={{ height: '75vh', width: '100%', minHeight: '544px' }}
+    >
+      <ZoomControl position="bottomright" />
+      <TileLayer {...tileLayer} />
+      <LayersControl position="topright">
+        <LayersControl.Overlay name="Marker with popup">
+          <Marker position={center}>
+            <Popup>
+              Populate the popups here <br /> Add new control overlays for
+              different locations
+            </Popup>
+          </Marker>
+        </LayersControl.Overlay>
+      </LayersControl>
+    </MapContainer>
+  );
+}
+
+export default SiteMap;

--- a/src/components/userComponents/SiteMap/SiteMap.tsx
+++ b/src/components/userComponents/SiteMap/SiteMap.tsx
@@ -30,6 +30,7 @@ function SiteMap() {
       zoomControl={false}
       scrollWheelZoom
       style={{ height: '75vh', width: '100%', minHeight: '544px' }}
+      key={new Date().getTime()}
     >
       <ZoomControl position="bottomright" />
       <TileLayer {...tileLayer} />

--- a/src/components/userComponents/navBar/navBar.tsx
+++ b/src/components/userComponents/navBar/navBar.tsx
@@ -8,7 +8,7 @@ function NavBar() {
     setShowMenu(!showMenu);
   }
 
-  function handleKeyDown(event: React.KeyboardEvent<HTMLDivElement>) {
+  function handleKeyDown(event: React.KeyboardEvent<HTMLButtonElement>) {
     if (event.key === 'Escape') {
       setShowMenu(false);
     }
@@ -65,7 +65,7 @@ function NavBar() {
       </button>
 
       {showMenu && (
-        <div className="fixed top-20 right-0 h-full w-3/5 bg-[#ebf0e4] shadow-lg">
+        <div className="fixed top-20 right-0 h-full w-3/5 bg-[#ebf0e4] shadow-lg z-[9999]">
             <h1 className="text-xl text-black font-bold p-4">WELCOME</h1>
           <ul className="p-4">
             <Link href="/" className="block mb-2 text-black">


### PR DESCRIPTION
# ✨ New in this PR ✨

## One liner: what did you do? 🛠
Adds React Leaflet map to Site Map page, created in #4 

## TODO 

- [x] Create Sitemap component and page
- [x] Filter buttons' responsive styling clarify w/ claire

## How can the reviewer test your code? 👩‍💻
1. `npm run dev`
2. Navigate to `localhost:3000/siteMapPage`
3. Map should be centered at NPO provided address, navigate to top right button and select "Marker with popup" to view the center point
4. Outside the map, ensure that the filter buttons properly scroll 

## Demo

https://github.com/calblueprint/phs/assets/63211322/f8b75651-9db0-4c36-a216-7d7d8161e6e4



## Any bugs you encountered or still having trouble with? 🐛
_Error 'window is not defined' when importing Map component:_ https://stackoverflow.com/questions/75282154/referenceerror-window-is-not-defined-nextjs13-use-client-not-working 

_Uncaught Error: Map container is already initialized._
https://github.com/PaulLeCam/react-leaflet/issues/936 

## Resources 📔

_link online resources and related PRs_

🏚 cc: @andreisito @christophertorres1 
